### PR TITLE
Make protobuf encryption compatible with OpenSSL 1.1.0, use generic_result for goal results

### DIFF
--- a/libs/protobuf_comm/crypto.cpp
+++ b/libs/protobuf_comm/crypto.cpp
@@ -115,26 +115,29 @@ BufferEncryptor::encrypt(const std::string &plain, std::string &enc)
     enc_m += iv_size;
   }
 
-  EVP_CIPHER_CTX ctx;
-  if ( ! EVP_EncryptInit(&ctx, evp_cipher, key_, iv_hash))
+  EVP_CIPHER_CTX *ctx;
+  ctx = EVP_CIPHER_CTX_new();
+  if ( ! EVP_EncryptInit(ctx, evp_cipher, key_, iv_hash))
   {
     throw std::runtime_error("Could not initialize cipher context");
   }
 
   int outl = enc.size() - iv_size;
-  if ( ! EVP_EncryptUpdate(&ctx, enc_m, &outl,
+  if ( ! EVP_EncryptUpdate(ctx, enc_m, &outl,
 			   (unsigned char *)plain.c_str(), plain.size()) )
   {
     throw std::runtime_error("EncryptUpdate failed");
   }
 
   int plen = 0;
-  if ( ! EVP_EncryptFinal_ex(&ctx, enc_m + outl, &plen) ) {
+  if ( ! EVP_EncryptFinal_ex(ctx, enc_m + outl, &plen) ) {
     throw std::runtime_error("EncryptFinal failed");
   }
   outl += plen;
  
   enc.resize(outl + iv_size);
+
+  EVP_CIPHER_CTX_free(ctx);
 #else
   throw std::runtime_error("Encryption support not available");
 #endif
@@ -231,24 +234,27 @@ BufferDecryptor::decrypt(int cipher, const void *enc, size_t enc_size, void *pla
   unsigned char *enc_m = (unsigned char *)enc + iv_size;
   enc_size -= iv_size;
 
-  EVP_CIPHER_CTX ctx;
-  if ( ! EVP_DecryptInit(&ctx, evp_cipher, (const unsigned char *)keys_[cipher].c_str(), iv))
+  EVP_CIPHER_CTX *ctx;
+  ctx = EVP_CIPHER_CTX_new();
+  if ( ! EVP_DecryptInit(ctx, evp_cipher, (const unsigned char *)keys_[cipher].c_str(), iv))
   {
     throw std::runtime_error("Could not initialize cipher context");
   }
 
   int outl = plain_size;
-  if ( ! EVP_DecryptUpdate(&ctx,
+  if ( ! EVP_DecryptUpdate(ctx,
 			   (unsigned char *)plain, &outl, enc_m, enc_size))
   {
     throw std::runtime_error("DecryptUpdate failed");
   }
 
   int plen = 0;
-  if ( ! EVP_DecryptFinal(&ctx, (unsigned char *)plain + outl, &plen) ) {
+  if ( ! EVP_DecryptFinal(ctx, (unsigned char *)plain + outl, &plen) ) {
     throw std::runtime_error("DecryptFinal failed");
   }
   outl += plen;
+
+  EVP_CIPHER_CTX_free(ctx);
 
   return outl;
 #else

--- a/proto/RobotState.proto
+++ b/proto/RobotState.proto
@@ -87,5 +87,14 @@ message RobotState {
   
   // Generic benchmark goal's result
   optional string generic_result = 37;
+
+  // HPPF: Person name
+  optional string person_name = 38
+  // HPPF: Person position, X
+  optional double person_pose_x = 39
+  // HPPF: Person position, Y
+  optional double person_pose_y = 40
+  // HPPF: Person position, Theta
+  optional double person_pose_theta = 41
   
 }

--- a/proto/RobotState.proto
+++ b/proto/RobotState.proto
@@ -74,27 +74,6 @@ message RobotState {
   // False means it should display the call button
   optional bool tablet_display_map = 22;
   
-  // HOPF: Object class
-  optional string object_class = 32;
-  // HOPF: Object name
-  optional string object_name = 33;
-  // HOPF: Object position, X
-  optional double object_pose_x = 34;
-  // HOPF: Object position, Y
-  optional double object_pose_y = 35;
-  // HOPF: Object position, Theta
-  optional double object_pose_theta = 36;
-  
   // Generic benchmark goal's result
-  optional string generic_result = 37;
-
-  // HPPF: Person name
-  optional string person_name = 38;
-  // HPPF: Person position, X
-  optional double person_pose_x = 39;
-  // HPPF: Person position, Y
-  optional double person_pose_y = 40;
-  // HPPF: Person position, Theta
-  optional double person_pose_theta = 41;
-  
+  optional string generic_result = 23;
 }

--- a/proto/RobotState.proto
+++ b/proto/RobotState.proto
@@ -89,12 +89,12 @@ message RobotState {
   optional string generic_result = 37;
 
   // HPPF: Person name
-  optional string person_name = 38
+  optional string person_name = 38;
   // HPPF: Person position, X
-  optional double person_pose_x = 39
+  optional double person_pose_x = 39;
   // HPPF: Person position, Y
-  optional double person_pose_y = 40
+  optional double person_pose_y = 40;
   // HPPF: Person position, Theta
-  optional double person_pose_theta = 41
+  optional double person_pose_theta = 41;
   
 }


### PR DESCRIPTION
To make RSBB run on Ubuntu 16/18 and ROS Kinetic/Melodic, updated protobuf encryption code to be compatible with OpenSSL 1.1.0 [like explained here](https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes#Compatibility_Layer).

Also, the `generic_result` protobuf field is now used to send any goal results in yaml format, so I've removed other fields.